### PR TITLE
Add core pipeline for local voice translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/src/audio/capture.py
+++ b/src/audio/capture.py
@@ -1,0 +1,71 @@
+import asyncio
+import sounddevice as sd
+import numpy as np
+from typing import AsyncGenerator, Optional
+
+
+class MicCapture:
+    """Captura audio mono PCM16 a 16 kHz en frames de N ms.
+
+    Entrega frames de tamaño fijo (p.ej. 20 ms) como bytes `int16`.
+    """
+
+    def __init__(self, device_name: Optional[str], samplerate: int = 16000, frame_ms: int = 20, exclusive: bool = False):
+        self.samplerate = samplerate
+        self.frame_ms = frame_ms
+        self.blocksize = int(samplerate * frame_ms / 1000)
+        self.bytes_per_frame = self.blocksize * 2  # int16
+        self._queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=256)
+
+        extra = None
+        try:
+            extra = sd.WasapiSettings(exclusive=exclusive)
+        except Exception:
+            extra = None
+
+        device = None
+        if device_name:
+            device = self._find_device(device_name)
+
+        self.stream = sd.RawInputStream(
+            samplerate=self.samplerate,
+            blocksize=self.blocksize,
+            channels=1,
+            dtype="int16",
+            device=device,
+            extra_settings=extra,
+            callback=self._callback,
+        )
+        self.stream.start()
+
+    def _find_device(self, hint: str):
+        """Busca por subcadenas case-insensitive en la lista de dispositivos."""
+        hint_low = hint.lower()
+        for idx, dev in enumerate(sd.query_devices()):
+            name = dev.get("name", "").lower()
+            if hint_low in name:
+                return idx
+        return None
+
+    def _callback(self, indata, frames, time, status):
+        if status:
+            # No levantar excepciones desde el hilo de PortAudio
+            pass
+        data = bytes(indata[: frames * 2])  # ya es int16 raw
+        try:
+            loop = asyncio.get_event_loop()
+            loop.call_soon_threadsafe(self._queue.put_nowait, data)
+        except RuntimeError:
+            # Event loop cerrado
+            pass
+
+    async def frames(self) -> AsyncGenerator[bytes, None]:
+        while True:
+            chunk = await self._queue.get()
+            yield chunk
+
+    def close(self):
+        try:
+            self.stream.stop(); self.stream.close()
+        except Exception:
+            pass

--- a/src/audio/sink.py
+++ b/src/audio/sink.py
@@ -1,0 +1,47 @@
+import sounddevice as sd
+
+
+class AudioSink:
+    """Salida raw a VB-Cable (u otro) en PCM16.
+
+    Escribe bytes `int16` al dispositivo de salida.
+    """
+
+    def __init__(self, device_hint: str = "CABLE Input", samplerate: int = 22050, channels: int = 1, exclusive: bool = False):
+        self.samplerate = samplerate
+        self.channels = channels
+        extra = None
+        try:
+            extra = sd.WasapiSettings(exclusive=exclusive)
+        except Exception:
+            extra = None
+
+        device = self._find_device(device_hint) if device_hint else None
+
+        self.stream = sd.RawOutputStream(
+            samplerate=self.samplerate,
+            channels=self.channels,
+            dtype="int16",
+            device=device,
+            extra_settings=extra,
+        )
+        self.stream.start()
+
+    def _find_device(self, hint: str):
+        hint_low = hint.lower()
+        for idx, dev in enumerate(sd.query_devices()):
+            name = dev.get("name", "").lower()
+            if hint_low in name:
+                return idx
+        return None
+
+    def write(self, audio_bytes: bytes):
+        if not audio_bytes:
+            return
+        self.stream.write(audio_bytes)
+
+    def close(self):
+        try:
+            self.stream.stop(); self.stream.close()
+        except Exception:
+            pass

--- a/src/audio/vad.py
+++ b/src/audio/vad.py
@@ -1,0 +1,59 @@
+import asyncio
+import collections
+import time
+import webrtcvad
+
+
+class VADSegmenter:
+    """Corta en *utterances* usando WebRTC VAD.
+
+    - Entrada: frames PCM16 (bytes) de `frame_ms` a `sample_rate`.
+    - Salida: bytes concatenados (utterance completa).
+    """
+
+    def __init__(self, sample_rate=16000, frame_ms=20, padding_ms=400, aggressiveness=2):
+        assert frame_ms in (10, 20, 30)
+        self.sample_rate = sample_rate
+        self.frame_ms = frame_ms
+        self.bytes_per_frame = int(sample_rate * frame_ms / 1000) * 2
+        self.vad = webrtcvad.Vad(aggressiveness)
+        self.num_pad = max(1, padding_ms // frame_ms)
+
+    async def segments(self, frames_q: asyncio.Queue):
+        ring = collections.deque(maxlen=self.num_pad)
+        voiced_frames = bytearray()
+        triggered = False
+        silence_count = 0
+        while True:
+            frame: bytes = await frames_q.get()
+            # Normalizar tamaño exacto de frame
+            if len(frame) != self.bytes_per_frame:
+                # Relleno/corte para VAD
+                if len(frame) < self.bytes_per_frame:
+                    frame = frame + b"\x00" * (self.bytes_per_frame - len(frame))
+                else:
+                    frame = frame[: self.bytes_per_frame]
+
+            is_speech = self.vad.is_speech(frame, self.sample_rate)
+
+            if not triggered:
+                ring.append((frame, is_speech))
+                num_voiced = sum(1 for _, s in ring if s)
+                if num_voiced > 0.6 * ring.maxlen:
+                    triggered = True
+                    for f, _ in ring:
+                        voiced_frames.extend(f)
+                    ring.clear()
+            else:
+                voiced_frames.extend(frame)
+                ring.append((frame, is_speech))
+                if not is_speech:
+                    silence_count += 1
+                else:
+                    silence_count = 0
+
+                if silence_count >= self.num_pad:
+                    # Fin de utterance
+                    yield bytes(voiced_frames)
+                    voiced_frames = bytearray()
+                    ring.clear(); triggered = False; silence_count = 0

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,114 @@
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+from rich.console import Console
+from rich.traceback import install as rich_install
+
+from audio.capture import MicCapture
+from audio.vad import VADSegmenter
+from audio.sink import AudioSink
+from pipeline.asr import FasterWhisperASR
+from pipeline.translate import NLLBTranslator
+from pipeline.tts import PiperTTS
+from utils.timing import StageTimer
+
+console = Console()
+rich_install(show_locals=False)
+
+
+async def pipeline_cli(args):
+    # Queues entre etapas
+    frames_q = asyncio.Queue(maxsize=256)        # bytes PCM16 16kHz 20ms
+    utterances_q = asyncio.Queue(maxsize=16)     # bytes PCM16 concatenados
+
+    # 1) Captura + VAD
+    mic = MicCapture(device_name=args.input, samplerate=16000, frame_ms=20, exclusive=args.exclusive)
+    vad = VADSegmenter(sample_rate=16000, frame_ms=20, padding_ms=400, aggressiveness=2)
+
+    # 2) ASR + MT + TTS + Sink
+    asr = FasterWhisperASR(model_size=args.whisper, device="cuda", compute_type="float16")
+    mt = NLLBTranslator(model_name="facebook/nllb-200-distilled-600M", device="cuda")
+
+    # Cargamos TTS y salida VB-Cable (samplerate de la voz)
+    tts = PiperTTS(model_path=args.piper_model, use_cuda=True)
+    sink = AudioSink(device_hint=args.output, samplerate=tts.sample_rate, channels=1, exclusive=args.exclusive)
+
+    timer = StageTimer()
+
+    async def capture_task():
+        async for frame in mic.frames():
+            await frames_q.put(frame)
+
+    async def vad_task():
+        async for segment in vad.segments(frames_q):
+            await utterances_q.put(segment)
+
+    async def nlp_task():
+        while True:
+            pcm = await utterances_q.get()
+            with timer.stage("total"):
+                with timer.stage("asr"):
+                    es_text = await asr.transcribe(pcm, language="es")
+                with timer.stage("mt"):
+                    en_text = await mt.translate(es_text, src_lang="spa_Latn", tgt_lang="eng_Latn")
+                console.log(f"[bold cyan]ES:[/bold cyan] {es_text}")
+                console.log(f"[bold green]EN:[/bold green] {en_text}")
+                with timer.stage("tts"):
+                    # stream directo al sink para mínima latencia
+                    for chunk in tts.synthesize_stream_raw(en_text):
+                        sink.write(chunk)
+            console.log(timer.summary())
+            utterances_q.task_done()
+
+    # Orquestación
+    tasks = [
+        asyncio.create_task(capture_task(), name="capture"),
+        asyncio.create_task(vad_task(), name="vad"),
+        asyncio.create_task(nlp_task(), name="nlp"),
+    ]
+
+    try:
+        await asyncio.gather(*tasks)
+    except asyncio.CancelledError:
+        pass
+    finally:
+        mic.close()
+        sink.close()
+
+
+def build_arg_parser():
+    p = argparse.ArgumentParser(description="LocalVoiceTranslate (offline ES→EN)")
+    p.add_argument("--nogui", action="store_true", help="Ejecutar en modo CLI")
+    p.add_argument("--input", default=None, help="Nombre/parcial del micrófono de entrada (WASAPI)")
+    p.add_argument("--output", default="CABLE Input", help="Nombre/parcial del dispositivo de salida (VB-Cable)")
+    p.add_argument("--exclusive", action="store_true", help="WASAPI exclusive mode (menor latencia)")
+    p.add_argument("--whisper", default="small", help="Tamaño modelo faster-whisper (small/medium/large-v3, etc.)")
+    p.add_argument("--piper-model", default=str(Path(__file__).resolve().parents[1] / "models/piper/en_US-lessac-medium.onnx"),
+                   help="Ruta al modelo Piper .onnx")
+    return p
+
+
+def main():
+    args = build_arg_parser().parse_args()
+
+    if args.nogui:
+        asyncio.run(pipeline_cli(args))
+    else:
+        # Lanzar GUI con qasync
+        from PySide6.QtWidgets import QApplication
+        from qasync import QEventLoop
+        from ui.main_window import MainWindow
+
+        app = QApplication(sys.argv)
+        loop = QEventLoop(app)
+        asyncio.set_event_loop(loop)
+        win = MainWindow(args)
+        win.show()
+        with loop:
+            loop.run_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pipeline/asr.py
+++ b/src/pipeline/asr.py
@@ -1,0 +1,27 @@
+import asyncio
+import numpy as np
+from faster_whisper import WhisperModel
+
+
+class FasterWhisperASR:
+    def __init__(self, model_size: str = "small", device: str = "cuda", compute_type: str = "float16"):
+        self.model = WhisperModel(model_size, device=device, compute_type=compute_type)
+
+    async def transcribe(self, pcm16_bytes: bytes, language: str = "es") -> str:
+        """Transcribe PCM16 16k mono → texto.
+        Usa un hilo del pool para no bloquear el event loop.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._sync_transcribe, pcm16_bytes, language)
+
+    def _sync_transcribe(self, pcm16_bytes: bytes, language: str) -> str:
+        audio = np.frombuffer(pcm16_bytes, dtype=np.int16).astype(np.float32) / 32768.0
+        segments, info = self.model.transcribe(
+            audio,
+            language=language,
+            beam_size=5,
+            vad_filter=False,
+            condition_on_previous_text=False,
+        )
+        text_parts = [seg.text for seg in segments]
+        return " ".join(text_parts).strip()

--- a/src/pipeline/translate.py
+++ b/src/pipeline/translate.py
@@ -1,0 +1,26 @@
+from typing import Optional
+import torch
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
+
+class NLLBTranslator:
+    def __init__(self, model_name: str, device: str = "cuda"):
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name, torch_dtype=torch.float16).to(device)
+        self.device = device
+        self.eng_id = self.tokenizer.convert_tokens_to_ids("eng_Latn")
+
+    async def translate(self, text: str, src_lang: str = "spa_Latn", tgt_lang: str = "eng_Latn", max_new_tokens: int = 256) -> str:
+        # NLLB usa src_lang en el tokenizer, y forced_bos_token_id para el idioma de salida
+        self.tokenizer.src_lang = src_lang
+        inputs = self.tokenizer([text], return_tensors="pt").to(self.model.device)
+        with torch.no_grad():
+            generated = self.model.generate(
+                **inputs,
+                forced_bos_token_id=self.eng_id,
+                max_new_tokens=max_new_tokens,
+                num_beams=3,
+                no_repeat_ngram_size=3,
+            )
+        out = self.tokenizer.batch_decode(generated, skip_special_tokens=True)
+        return out[0]

--- a/src/pipeline/tts.py
+++ b/src/pipeline/tts.py
@@ -1,0 +1,15 @@
+from typing import Iterable
+from piper.voice import PiperVoice
+
+
+class PiperTTS:
+    def __init__(self, model_path: str, use_cuda: bool = True):
+        # Piper busca el .json junto al .onnx automáticamente
+        self.voice = PiperVoice.load(model_path, use_cuda=use_cuda)
+        self.sample_rate = self.voice.config.sample_rate
+
+    def synthesize_stream_raw(self, text: str) -> Iterable[bytes]:
+        """Genera PCM16 (bytes) mientras se sintetiza (streaming)."""
+        for chunk in self.voice.synthesize_stream_raw(text):
+            if chunk:
+                yield chunk

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1,0 +1,52 @@
+import asyncio
+from PySide6.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QPushButton, QLabel, QComboBox
+from qasync import asyncSlot
+import sounddevice as sd
+
+
+class MainWindow(QMainWindow):
+    def __init__(self, args):
+        super().__init__()
+        self.setWindowTitle("LocalVoiceTranslate (ES→EN)")
+        self.args = args
+
+        root = QWidget(self)
+        lay = QVBoxLayout(root)
+        self.combo_in = QComboBox()
+        self.btn_start = QPushButton("Start")
+        self.btn_stop = QPushButton("Stop")
+        self.latency_label = QLabel("latencia: —")
+
+        lay.addWidget(QLabel("Micrófono de entrada (WASAPI):"))
+        lay.addWidget(self.combo_in)
+        lay.addWidget(self.btn_start)
+        lay.addWidget(self.btn_stop)
+        lay.addWidget(self.latency_label)
+        self.setCentralWidget(root)
+
+        self._populate_inputs()
+        self.btn_start.clicked.connect(self.start)
+        self.btn_stop.clicked.connect(self.stop)
+
+        self._task = None
+
+    def _populate_inputs(self):
+        self.combo_in.clear()
+        for d in sd.query_devices():
+            name = d.get("name", "")
+            self.combo_in.addItem(name)
+
+    @asyncSlot()
+    async def start(self):
+        if self._task and not self._task.done():
+            return
+        # Re-lanzar main CLI pipeline reusando args
+        import src.main as main_mod  # evitar import circular
+        a = self.args
+        a.input = self.combo_in.currentText()
+        self._task = asyncio.create_task(main_mod.pipeline_cli(a))
+
+    @asyncSlot()
+    async def stop(self):
+        if self._task:
+            self._task.cancel()

--- a/src/utils/timing.py
+++ b/src/utils/timing.py
@@ -1,0 +1,22 @@
+import time
+from contextlib import contextmanager
+
+
+class StageTimer:
+    def __init__(self):
+        self._stamps = {}
+        self._last = None
+
+    @contextmanager
+    def stage(self, name: str):
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            end = time.perf_counter()
+            self._stamps[name] = self._stamps.get(name, 0.0) + (end - start)
+
+    def summary(self) -> str:
+        parts = [f"{k}={v*1000:.0f} ms" for k, v in self._stamps.items()]
+        self._stamps.clear()
+        return " | ".join(parts)


### PR DESCRIPTION
## Summary
- implement main CLI and GUI entry points for ES→EN translation
- add audio capture, VAD segmentation, and sink modules
- integrate faster-whisper ASR, NLLB translation, and Piper TTS
- include simple stage timer and `.gitignore`

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile $(find src -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6895bcbd8cfc832c8e5dfb73415889dc