### PR TITLE
Add unit tests for utilities and audio helpers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+# Add src directory to sys.path for tests
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))

--- a/tests/test_audio_devices.py
+++ b/tests/test_audio_devices.py
@@ -1,0 +1,31 @@
+import sys
+import types
+
+# Provide a minimal stub for the sounddevice module used during imports
+sd_stub = types.SimpleNamespace(
+    query_devices=lambda: [],
+    WasapiSettings=lambda *args, **kwargs: None,
+    RawInputStream=object,
+    RawOutputStream=object,
+)
+sys.modules.setdefault('sounddevice', sd_stub)
+
+from audio.capture import MicCapture
+from audio.sink import AudioSink
+from unittest.mock import patch
+
+
+def test_mic_capture_find_device():
+    mc = MicCapture.__new__(MicCapture)
+    devices = [{'name': 'Device A'}, {'name': 'My Mic'}, {'name': 'Other'}]
+    with patch('audio.capture.sd.query_devices', return_value=devices):
+        assert mc._find_device('my mic') == 1
+        assert mc._find_device('unknown') is None
+
+
+def test_audio_sink_find_device():
+    sink = AudioSink.__new__(AudioSink)
+    devices = [{'name': 'Alpha'}, {'name': 'Beta Device'}]
+    with patch('audio.sink.sd.query_devices', return_value=devices):
+        assert sink._find_device('beta') == 1
+        assert sink._find_device('gamma') is None

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,14 @@
+import time
+from utils.timing import StageTimer
+
+
+def test_stage_timer_accumulates_and_clears():
+    timer = StageTimer()
+    with timer.stage('phase'):
+        time.sleep(0.001)
+    with timer.stage('phase'):
+        time.sleep(0.001)
+    summary = timer.summary()
+    assert 'phase=' in summary
+    assert timer._stamps == {}
+    assert timer.summary() == ''

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -1,0 +1,23 @@
+import asyncio
+import pytest
+from audio.vad import VADSegmenter
+
+
+class FakeVAD:
+    def is_speech(self, frame: bytes, sample_rate: int) -> bool:
+        return frame[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_vad_segmenter_segments_frames():
+    seg = VADSegmenter(sample_rate=16000, frame_ms=20, padding_ms=40)
+    seg.vad = FakeVAD()
+    q = asyncio.Queue()
+    speech = b'\x01' * seg.bytes_per_frame
+    silence = b'\x00' * seg.bytes_per_frame
+    for frame in [speech, speech, silence, silence]:
+        await q.put(frame)
+    gen = seg.segments(q)
+    utterance = await asyncio.wait_for(gen.__anext__(), timeout=1)
+    assert utterance == speech + speech + silence + silence
+    await gen.aclose()


### PR DESCRIPTION
## Summary
- add tests for StageTimer summary clearing
- add tests for audio device lookup helpers with sounddevice stub
- add tests for VADSegmenter frame segmentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6895c788b220832ca01c371f6f67c845