### PR TITLE
Add dynamic hardware profiles with latency metrics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ soundfile>=0.12  # útil para depurar, no obligatorio
 
 # ASR
 faster-whisper>=1.1
+vosk>=0.3.45
 
 # MT
 transformers>=4.43
@@ -16,6 +17,7 @@ torch  # instalarse con el index de CUDA 12.1 (ver README)
 # TTS
 piper-tts>=1.2
 onnxruntime-gpu>=1.17
+TTS>=0.14
 
 # UI
 PySide6>=6.7

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 import argparse
 import asyncio
 import sys
-from pathlib import Path
+import torch
 
 from rich.console import Console
 from rich.traceback import install as rich_install
@@ -9,9 +9,8 @@ from rich.traceback import install as rich_install
 from audio.capture import MicCapture
 from audio.vad import VADSegmenter
 from audio.sink import AudioSink
-from pipeline.asr import FasterWhisperASR
 from pipeline.translate import NLLBTranslator
-from pipeline.tts import PiperTTS
+from profiles import select_profile, build_profile
 from utils.timing import StageTimer
 
 console = Console()
@@ -28,11 +27,13 @@ async def pipeline_cli(args):
     vad = VADSegmenter(sample_rate=16000, frame_ms=20, padding_ms=400, aggressiveness=2)
 
     # 2) ASR + MT + TTS + Sink
-    asr = FasterWhisperASR(model_size=args.whisper, device="cuda", compute_type="float16")
-    mt = NLLBTranslator(model_name="facebook/nllb-200-distilled-600M", device="cuda")
-
-    # Cargamos TTS y salida VB-Cable (samplerate de la voz)
-    tts = PiperTTS(model_path=args.piper_model, use_cuda=True)
+    profile = select_profile() if args.profile == "auto" else build_profile(args.profile)
+    asr = profile.asr
+    tts = profile.tts
+    mt = NLLBTranslator(
+        model_name="facebook/nllb-200-distilled-600M",
+        device="cuda" if torch.cuda.is_available() else "cpu",
+    )
     sink = AudioSink(device_hint=args.output, samplerate=tts.sample_rate, channels=1, exclusive=args.exclusive)
 
     timer = StageTimer()
@@ -48,6 +49,7 @@ async def pipeline_cli(args):
     async def nlp_task():
         while True:
             pcm = await utterances_q.get()
+            audio_sec = len(pcm) / (2 * 16000)
             with timer.stage("total"):
                 with timer.stage("asr"):
                     es_text = await asr.transcribe(pcm, language="es")
@@ -59,7 +61,7 @@ async def pipeline_cli(args):
                     # stream directo al sink para mínima latencia
                     for chunk in tts.synthesize_stream_raw(en_text):
                         sink.write(chunk)
-            console.log(timer.summary())
+            console.log(timer.summary(audio_sec))
             utterances_q.task_done()
 
     # Orquestación
@@ -84,9 +86,9 @@ def build_arg_parser():
     p.add_argument("--input", default=None, help="Nombre/parcial del micrófono de entrada (WASAPI)")
     p.add_argument("--output", default="CABLE Input", help="Nombre/parcial del dispositivo de salida (VB-Cable)")
     p.add_argument("--exclusive", action="store_true", help="WASAPI exclusive mode (menor latencia)")
-    p.add_argument("--whisper", default="small", help="Tamaño modelo faster-whisper (small/medium/large-v3, etc.)")
-    p.add_argument("--piper-model", default=str(Path(__file__).resolve().parents[1] / "models/piper/en_US-lessac-medium.onnx"),
-                   help="Ruta al modelo Piper .onnx")
+    p.add_argument("--profile", default="auto",
+                   choices=["auto", "cpu-light", "gpu-medium", "gpu-high"],
+                   help="Perfil de hardware/modelos")
     return p
 
 

--- a/src/pipeline/asr.py
+++ b/src/pipeline/asr.py
@@ -1,6 +1,8 @@
 import asyncio
+import json
 import numpy as np
 from faster_whisper import WhisperModel
+from vosk import Model, KaldiRecognizer
 
 
 class FasterWhisperASR:
@@ -25,3 +27,18 @@ class FasterWhisperASR:
         )
         text_parts = [seg.text for seg in segments]
         return " ".join(text_parts).strip()
+
+
+class VoskASR:
+    def __init__(self, model_path: str):
+        self.model = Model(model_path)
+
+    async def transcribe(self, pcm16_bytes: bytes, language: str = "es") -> str:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._sync_transcribe, pcm16_bytes)
+
+    def _sync_transcribe(self, pcm16_bytes: bytes) -> str:
+        recognizer = KaldiRecognizer(self.model, 16000)
+        recognizer.AcceptWaveform(pcm16_bytes)
+        result = json.loads(recognizer.Result())
+        return result.get("text", "").strip()

--- a/src/pipeline/tts.py
+++ b/src/pipeline/tts.py
@@ -1,5 +1,8 @@
 from typing import Iterable
+
+import numpy as np
 from piper.voice import PiperVoice
+from TTS.api import TTS as CoquiTTS
 
 
 class PiperTTS:
@@ -13,3 +16,14 @@ class PiperTTS:
         for chunk in self.voice.synthesize_stream_raw(text):
             if chunk:
                 yield chunk
+
+
+class XTTSTTS:
+    def __init__(self, model_name: str = "tts_models/en/ljspeech/xtts_v2"):
+        self.tts = CoquiTTS(model_name)
+        self.sample_rate = self.tts.synthesizer.output_sample_rate
+
+    def synthesize_stream_raw(self, text: str) -> Iterable[bytes]:
+        wav = self.tts.tts(text)
+        pcm = (np.array(wav) * 32767).astype(np.int16).tobytes()
+        yield pcm

--- a/src/profiles.py
+++ b/src/profiles.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+
+import torch
+
+from pipeline.asr import FasterWhisperASR
+from pipeline.tts import PiperTTS
+
+
+@dataclass
+class Profile:
+    name: str
+    asr: object
+    tts: object
+
+
+def _available_vram() -> int:
+    """Return available VRAM in MB for the first CUDA device."""
+    try:
+        if torch.cuda.is_available():
+            props = torch.cuda.get_device_properties(0)
+            return props.total_memory // (1024 ** 2)
+    except Exception:
+        pass
+    return 0
+
+
+def detect_profile() -> str:
+    vram = _available_vram()
+    if vram >= 16000:  # 16 GB or more
+        return "gpu-high"
+    if vram >= 6000:   # 6 GB or more
+        return "gpu-medium"
+    return "cpu-light"
+
+
+def build_profile(name: str) -> Profile:
+    if name == "gpu-high":
+        from pipeline.tts import XTTSTTS
+        asr = FasterWhisperASR(model_size="medium", device="cuda", compute_type="float16")
+        tts = XTTSTTS()
+    elif name == "gpu-medium":
+        asr = FasterWhisperASR(model_size="small", device="cuda", compute_type="float16")
+        tts = PiperTTS(model_path="models/piper/en_US-lessac-medium.onnx", use_cuda=True)
+    else:
+        from pipeline.asr import VoskASR
+        asr = VoskASR(model_path="models/vosk-model-small-es-0.42")
+        tts = PiperTTS(model_path="models/piper/en_US-lessac-medium.onnx", use_cuda=False)
+    return Profile(name=name, asr=asr, tts=tts)
+
+
+def select_profile() -> Profile:
+    return build_profile(detect_profile())
+

--- a/src/utils/timing.py
+++ b/src/utils/timing.py
@@ -16,7 +16,11 @@ class StageTimer:
             end = time.perf_counter()
             self._stamps[name] = self._stamps.get(name, 0.0) + (end - start)
 
-    def summary(self) -> str:
+    def summary(self, audio_duration: float | None = None) -> str:
         parts = [f"{k}={v*1000:.0f} ms" for k, v in self._stamps.items()]
+        total = sum(self._stamps.values())
+        if audio_duration:
+            rtf = total / audio_duration if audio_duration > 0 else 0.0
+            parts.append(f"RTF={rtf:.2f}")
         self._stamps.clear()
         return " | ".join(parts)

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -8,7 +8,7 @@ def test_stage_timer_accumulates_and_clears():
         time.sleep(0.001)
     with timer.stage('phase'):
         time.sleep(0.001)
-    summary = timer.summary()
-    assert 'phase=' in summary
+    summary = timer.summary(audio_duration=0.01)
+    assert 'phase=' in summary and 'RTF=' in summary
     assert timer._stamps == {}
     assert timer.summary() == ''


### PR DESCRIPTION
## Summary
- detect available VRAM and pick CPU-light, GPU-medium, or GPU-high profile
- support Vosk ASR and XTTS TTS in addition to existing FasterWhisper/Piper
- report per-stage latency and real-time factor

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba8bf039fc832c82921eaefc9b4627