### PR TITLE
Add metrics logging and UI debug panel

### DIFF
--- a/src/audio/sink.py
+++ b/src/audio/sink.py
@@ -26,6 +26,7 @@ class AudioSink:
             extra_settings=extra,
         )
         self.stream.start()
+        self.underruns = 0
 
     def _find_device(self, hint: str):
         hint_low = hint.lower()
@@ -39,6 +40,12 @@ class AudioSink:
         if not audio_bytes:
             return
         self.stream.write(audio_bytes)
+        try:
+            status = self.stream.get_status()
+            if status.output_underflow:
+                self.underruns += 1
+        except Exception:
+            pass
 
     def close(self):
         try:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -2,6 +2,7 @@ import asyncio
 from PySide6.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QPushButton, QLabel, QComboBox
 from qasync import asyncSlot
 import sounddevice as sd
+import torch
 
 
 class MainWindow(QMainWindow):
@@ -16,12 +17,24 @@ class MainWindow(QMainWindow):
         self.btn_start = QPushButton("Start")
         self.btn_stop = QPushButton("Stop")
         self.latency_label = QLabel("latencia: —")
+        self.partial_label = QLabel("parcial: —")
+        self.final_label = QLabel("final: —")
+        self.fps_label = QLabel("FPS: —")
+        self.rtf_label = QLabel("RTF: —")
+        self.gpu_label = QLabel("GPU: —")
+        self.vram_label = QLabel("VRAM: —")
 
         lay.addWidget(QLabel("Micrófono de entrada (WASAPI):"))
         lay.addWidget(self.combo_in)
         lay.addWidget(self.btn_start)
         lay.addWidget(self.btn_stop)
         lay.addWidget(self.latency_label)
+        lay.addWidget(self.partial_label)
+        lay.addWidget(self.final_label)
+        lay.addWidget(self.fps_label)
+        lay.addWidget(self.rtf_label)
+        lay.addWidget(self.gpu_label)
+        lay.addWidget(self.vram_label)
         self.setCentralWidget(root)
 
         self._populate_inputs()
@@ -44,9 +57,30 @@ class MainWindow(QMainWindow):
         import src.main as main_mod  # evitar import circular
         a = self.args
         a.input = self.combo_in.currentText()
-        self._task = asyncio.create_task(main_mod.pipeline_cli(a))
+        self._task = asyncio.create_task(main_mod.pipeline_cli(a, ui_callback=self.update_debug))
 
     @asyncSlot()
     async def stop(self):
         if self._task:
             self._task.cancel()
+
+    def update_debug(self, partial=None, final=None, metrics=None):
+        if partial is not None:
+            self.partial_label.setText(f"parcial: {partial}")
+        if final is not None:
+            self.final_label.setText(f"final: {final}")
+        if metrics:
+            fps = 1.0 / metrics["t_final"] if metrics["t_final"] else 0.0
+            self.fps_label.setText(f"FPS: {fps:.2f}")
+            self.rtf_label.setText(f"RTF: {metrics['rtf']:.2f}")
+            util = mem_alloc = mem_total = 0
+            if torch.cuda.is_available():
+                dev = torch.cuda.current_device()
+                try:
+                    util = torch.cuda.utilization(dev)
+                except Exception:
+                    util = 0
+                mem_alloc = torch.cuda.memory_allocated(dev) / (1024 ** 2)
+                mem_total = torch.cuda.get_device_properties(dev).total_memory / (1024 ** 2)
+            self.gpu_label.setText(f"GPU: {util:.0f}%")
+            self.vram_label.setText(f"VRAM: {mem_alloc/1024:.1f}/{mem_total/1024:.1f} GB")


### PR DESCRIPTION
## Summary
- Track audio sink underruns and expose counter
- Log per-block timing metrics and forward them to an optional UI callback
- Expand UI with debug panel showing partial/final text, FPS/RTF and GPU/VRAM usage

## Testing
- `pip install pytest-asyncio -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba8c05365c832c82422ecc865159f2